### PR TITLE
Open rosbags in input directory instead of the cwd

### DIFF
--- a/scripts/rosbags_to_directories.py
+++ b/scripts/rosbags_to_directories.py
@@ -2,6 +2,7 @@ import os
 
 from rosbag_extractor import RosbagExtractor
 from rosbag_to_directory import load_config
+from pathlib import Path
 
 ################## PARAMETERS ##################
 
@@ -9,15 +10,15 @@ INPUT_BAGS = []
 INPUT_FOLDERS = [
     "/run/user/1000/gvfs/afp-volume:host=bucheron.local,user=norlab_admin,volume=home/olivier_gamache/dataset/forest_04-20-2023/bagfiles/",
     "/run/user/1000/gvfs/afp-volume:host=bucheron.local,user=norlab_admin,volume=home/olivier_gamache/dataset/forest_04-21-2023/bagfiles/",
-    "/run/user/1000/gvfs/afp-volume:host=bucheron.local,user=norlab_admin,volume=home/olivier_gamache/dataset/belair_09-27-2023/bagfiles/"
+    "/run/user/1000/gvfs/afp-volume:host=bucheron.local,user=norlab_admin,volume=home/olivier_gamache/dataset/belair_09-27-2023/bagfiles/",
 ]
 OUTPUT_FOLDER = "/home/jean-michel/Desktop/test"
 CONFIG_FILE = os.path.join(os.path.dirname(__file__), "../configs/config_backpack.json")
 
 ################################################
 
+
 def main():
-    
     config_dict = load_config(CONFIG_FILE)
 
     if len(INPUT_BAGS) > 0:
@@ -28,8 +29,10 @@ def main():
 
     elif len(INPUT_FOLDERS) > 0:
         for INPUT_FOLDER in INPUT_FOLDERS:
-            for bag_file in os.listdir(INPUT_FOLDER):
-                output_folder = os.path.join(OUTPUT_FOLDER, bag_file.split(".")[0])
+            input_dir = Path(INPUT_FOLDER)
+            bag_files = (f.parent for f in input_dir.glob("**/metadata.yaml"))
+            for bag_file in bag_files:
+                output_folder = os.path.join(OUTPUT_FOLDER, bag_file.stem)
                 rosbag_extractor = RosbagExtractor(bag_file, config_dict)
                 rosbag_extractor.extract_data(output_folder, overwrite=True)
 


### PR DESCRIPTION
* Open rosbags in input directory instead of the cwd
  The current script was opening the rosbags by considering that they are in the cwd.
  We instead use the input folder for each rosbag.
* Only open bagfiles when they are in a directory with a `metadata.yaml`.
  In some cases, we may add a output directory directly in the directory with the rosbags. This fix avoids running the script against its own output.